### PR TITLE
FIX #25 autocompletion works again. For this I deleted the whole eclipse

### DIFF
--- a/.externalToolBuilders/org.eclipse.wst.jsdt.core.javascriptValidator.launch
+++ b/.externalToolBuilders/org.eclipse.wst.jsdt.core.javascriptValidator.launch
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<launchConfiguration type="org.eclipse.ant.AntBuilderLaunchConfigurationType">
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_BUILDER_ENABLED" value="false"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_DISABLED_BUILDER" value="org.eclipse.wst.jsdt.core.javascriptValidator"/>
-<mapAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS"/>
-<booleanAttribute key="org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED" value="true"/>
-</launchConfiguration>

--- a/.project
+++ b/.project
@@ -10,16 +10,6 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.ui.externaltools.ExternalToolBuilder</name>
-			<triggers>full,incremental,</triggers>
-			<arguments>
-				<dictionary>
-					<key>LaunchConfigHandle</key>
-					<value>&lt;project&gt;/.externalToolBuilders/org.eclipse.wst.jsdt.core.javascriptValidator.launch</value>
-				</dictionary>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>com.palantir.typescript.typeScriptNature</nature>

--- a/.settings/com.palantir.typescript.prefs
+++ b/.settings/com.palantir.typescript.prefs
@@ -1,5 +1,14 @@
 build.path.exportedFolder=
 build.path.sourceFolder=app/ts
-compiler.outputDirOption=app/scripts/gen
-compiler.outputFileOption=eclipse.js
+compiler.codeGenTarget=ECMASCRIPT5
+compiler.compileOnSave=false
+compiler.generateDeclarationFiles=false
+compiler.mapSourceFiles=false
+compiler.moduleGenTarget=UNSPECIFIED
+compiler.noEmitOnError=true
+compiler.noImplicitAny=true
+compiler.noLib=false
+compiler.outputDirOption=
+compiler.outputFileOption=
+compiler.removeComments=false
 eclipse.preferences.version=1


### PR DESCRIPTION
relevant stuff and deleted the project from the project explorer. Next,
I imported the gitrepository as a new GENERAL project. Finally simply
enabled the typescript builder.
